### PR TITLE
修复 readme 安装脚本错误 ：install.sh: 8: Syntax error: "(" unexpected

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ PowerVim的安装非常简单，我已经写好了安装脚本，只要执行以
 ```bash
 git clone https://github.com/youngyangyang04/PowerVim.git
 cd PowerVim
-sh install.sh
+bash install.sh
 ```
 
 


### PR DESCRIPTION
在使用 sh install.sh 脚本安装 vim 配置时，会出现错误： install.sh: 8: Syntax error: "(" unexpected 
原因是：在一些系统中，sh 可能不会指向 bash，而是指向其他更传统或兼容性更强的 Shell，如 dash。dash 对于某些 bash 特性的支持不如 bash 本身
修复：使用 bash 而不是 sh 来执行脚本。通过以下命令来实现 bash install.sh 可以解决该 bug

下面是我遇到问题，并解决问题的具体情况：
pomelo@DESKTOP-TEJES18:~/PowerVim$ sh install.sh
install.sh: 8: Syntax error: "(" unexpected
pomelo@DESKTOP-TEJES18:~/PowerVim$ bash install.sh
\033[0;35mStart to install vim-conf\033[0m
\033[0;36mLooking for an existing vim config...\033[0m
\033[0;36mCopying .vimrc and .vim\033[0m
\033[0;32mln -s /home/pomelo/PowerVim/.vimrc .vimrc\033[0m
\033[0;32mln -s /home/pomelo/PowerVim/.vim .vim\033[0m
\033[0;32mln -s /home/pomelo/PowerVim/.ctags .ctags\033[0m
\033[0;35m  _____                    __      ___             \033[0m
\033[0;35m  |  __ \                   \ \    / (_)           \033[0m
\033[0;35m  | |__) |____      _____ _ _\ \  / / _ _ __ ___   \033[0m
\033[0;35m  |  ___/ _ \ \ /\ / / _ \ \__\ \/ / | |  _   _ \  \033[0m
\033[0;35m  | |  | (_) \ V  V /  __/ /   \  /  | | | | | | | \033[0m
\033[0;35m  |_|   \___/ \_/\_/ \___|_|    \/   |_|_| |_| |_| \033[0m
\n\n \033[0;35mEnjoy!.\033[0m